### PR TITLE
ch3: fix typo in "truth tables" section

### DIFF
--- a/forallx-ch3-truthtables.tex
+++ b/forallx-ch3-truthtables.tex
@@ -75,7 +75,7 @@ $H$&$I$&$(H$&\eand&$I)$&\eif&$H$\\
  0 & 0 &  & {0} &  &\TTbf{1} & 0
 \end{tabular}
 \end{center}
-The column of 1s underneath the conditional tells us that the sentence \mbox{$(H \eand I)\eif I$} is true regardless of the truth-values of $H$ and $I$. They can be true or false in any combination, and the compound sentence still comes out true. It is crucial that we have considered all of the possible combinations. If we only had a two-line truth table, we could not be sure that the sentence was not false for some other combination of truth-values.
+The column of 1s underneath the conditional tells us that the sentence \mbox{$(H \eand I)\eif H$} is true regardless of the truth-values of $H$ and $I$. They can be true or false in any combination, and the compound sentence still comes out true. It is crucial that we have considered all of the possible combinations. If we only had a two-line truth table, we could not be sure that the sentence was not false for some other combination of truth-values.
 
 In this example, we have not repeated all of the entries in every successive table. When actually writing truth tables on paper, however, it is impractical to erase whole columns or rewrite the whole table for every step. Although it is more crowded, the truth table can be written in this way:
 \begin{center}


### PR DESCRIPTION
The text is not incorrect as-is, but it is slightly confusing because the formula is a different one from the one that is being discussed.